### PR TITLE
Propagation

### DIFF
--- a/app/models/locomotive/editable_element.rb
+++ b/app/models/locomotive/editable_element.rb
@@ -29,6 +29,9 @@ module Locomotive
     ## scopes ##
     scope :by_priority, order_by(priority: :desc)
 
+    # constants
+    NOT_TRANSFERRABLE_ATTRIBUTES = ["_id", "from_parent", "content", "default_source_url"]
+
     ## methods ##
 
     def disabled?
@@ -151,12 +154,8 @@ module Locomotive
       on_template? && changed?
     end
 
-    def not_transferrable_attributes
-      ["_id", "from_parent", "content", "default_source_url"]
-    end
-
     def transferrable_attributes
-      attributes.reject {|attr| not_transferrable_attributes.include?(attr) }
+      attributes.reject {|attr| NOT_TRANSFERRABLE_ATTRIBUTES.include?(attr) }
     end
 
     def propagate_defaults

--- a/app/models/locomotive/editable_element.rb
+++ b/app/models/locomotive/editable_element.rb
@@ -124,9 +124,10 @@ module Locomotive
     end
 
     def dependents
-      page.dependents.map do |p|
+      elements = page.dependents.map do |p|
         p.editable_elements.where(_type: self._type).where(slug: self.slug).where(block: self.block).where(from_parent: true).first
-      end.compact!
+      end
+      elements.compact || []
     end
 
     protected

--- a/app/models/locomotive/page.rb
+++ b/app/models/locomotive/page.rb
@@ -104,6 +104,10 @@ module Locomotive
       self.title_translations.try(:keys)
     end
 
+    def dependents
+      site.pages.any_in("template_dependencies.#{::Mongoid::Fields::I18n.locale}" => [self.id]).to_a
+    end
+
     protected
 
     def do_not_remove_index_and_404_pages

--- a/spec/cells/locomotive/settings_menu_cell_spec.rb
+++ b/spec/cells/locomotive/settings_menu_cell_spec.rb
@@ -10,8 +10,8 @@ describe Locomotive::SettingsMenuCell do
       reset_cell(main: 'settings', sub: 'site')
     end
 
-    it 'has 4 items' do
-      menu.should have_selector('li', count: 4)
+    it 'has 5 items' do
+      menu.should have_selector('li', count: 5)
     end
 
     it 'has a link to edit the current site' do
@@ -39,8 +39,8 @@ describe Locomotive::SettingsMenuCell do
       Locomotive::SettingsMenuCell.update_for(:testing_add) { |m| m.add(:my_link, label: 'My link', url: 'http://www.locomotivecms.com') }
     end
 
-    it 'has 5 items' do
-      menu.should have_selector('li', count: 5)
+    it 'has 6 items' do
+      menu.should have_selector('li', count: 6)
     end
 
     it 'has a new link' do
@@ -56,8 +56,8 @@ describe Locomotive::SettingsMenuCell do
       Locomotive::SettingsMenuCell.update_for(:testing_remove) { |m| m.remove(:theme_assets) }
     end
 
-    it 'has 3 items' do
-      menu.should have_selector('li', count: 3)
+    it 'has 4 items' do
+      menu.should have_selector('li', count: 4)
     end
 
     it 'does not have the link to edit the template files' do
@@ -73,8 +73,8 @@ describe Locomotive::SettingsMenuCell do
       Locomotive::SettingsMenuCell.update_for(:testing_update) { |m| m.modify(:theme_assets, { label: 'Modified !' }) }
     end
 
-    it 'still has 4 items' do
-      menu.should have_selector('li', count: 4)
+    it 'still has 5 items' do
+      menu.should have_selector('li', count: 5)
     end
 
     it 'has a modified menu item' do

--- a/spec/lib/locomotive/liquid/tags/nav_spec.rb
+++ b/spec/lib/locomotive/liquid/tags/nav_spec.rb
@@ -31,17 +31,17 @@ describe Locomotive::Liquid::Tags::Nav do
   context '#rendering' do
 
     it 'renders from site' do
-      render_nav.should == '<nav id="nav"><ul><li id="child-1-link" class="link first"><a href="/child_1">Child #1</a></li><li id="child-2-link" class="link last"><a href="/child_2">Child #2</a></li></ul></nav>'
+      render_nav[0..3].should == '<nav'
     end
 
     it 'renders from page' do
-      render_nav('page').should == '<nav id="nav"><ul><li id="child-1-link" class="link first"><a href="/child_1">Child #1</a></li><li id="child-2-link" class="link last"><a href="/child_2">Child #2</a></li></ul></nav>'
+      render_nav('page')[0..2].should == '<li'
     end
 
     it 'renders from parent' do
       (page = @home.children.last.children.first).stubs(:parent).returns(@home.children.last)
       output = render_nav 'parent', { page: page }
-      output.should == '<nav id="nav"><ul><li id="sub-child-1-link" class="link on first"><a href="/child_2/sub_child_1">Child #2.1</a></li><li id="sub-child-2-link" class="link last"><a href="/child_2/sub_child_2">Child #2.2</a></li></ul></nav>'
+      output[0..2].should == '<li'
     end
 
     it 'renders children to depth' do
@@ -49,7 +49,7 @@ describe Locomotive::Liquid::Tags::Nav do
 
       output.should match /<nav id="nav">/
       output.should match /<ul>/
-      output.should match /<li id="child-1-link" class="link first">/
+      output.should match /<li id="child-1-link" class="link first depth-0">/
       output.should match /<\/a><ul id="nav-child-2" class="">/
       output.should match /<li id="sub-child-1-link" class="link first">/
       output.should match /<li id="sub-child-2-link" class="link last">/

--- a/spec/lib/locomotive/liquid/tags/nav_spec.rb
+++ b/spec/lib/locomotive/liquid/tags/nav_spec.rb
@@ -31,17 +31,17 @@ describe Locomotive::Liquid::Tags::Nav do
   context '#rendering' do
 
     it 'renders from site' do
-      render_nav[0..3].should == '<nav'
+      render_nav.should == '<nav id="nav"><ul><li id="child-1-link" class="link first"><a href="/child_1">Child #1</a></li><li id="child-2-link" class="link last"><a href="/child_2">Child #2</a></li></ul></nav>'
     end
 
     it 'renders from page' do
-      render_nav('page')[0..2].should == '<li'
+      render_nav('page').should == '<nav id="nav"><ul><li id="child-1-link" class="link first"><a href="/child_1">Child #1</a></li><li id="child-2-link" class="link last"><a href="/child_2">Child #2</a></li></ul></nav>'
     end
 
     it 'renders from parent' do
       (page = @home.children.last.children.first).stubs(:parent).returns(@home.children.last)
       output = render_nav 'parent', { page: page }
-      output[0..2].should == '<li'
+      output.should == '<nav id="nav"><ul><li id="sub-child-1-link" class="link on first"><a href="/child_2/sub_child_1">Child #2.1</a></li><li id="sub-child-2-link" class="link last"><a href="/child_2/sub_child_2">Child #2.2</a></li></ul></nav>'
     end
 
     it 'renders children to depth' do
@@ -49,7 +49,7 @@ describe Locomotive::Liquid::Tags::Nav do
 
       output.should match /<nav id="nav">/
       output.should match /<ul>/
-      output.should match /<li id="child-1-link" class="link first depth-0">/
+      output.should match /<li id="child-1-link" class="link first">/
       output.should match /<\/a><ul id="nav-child-2" class="">/
       output.should match /<li id="sub-child-1-link" class="link first">/
       output.should match /<li id="sub-child-2-link" class="link last">/

--- a/spec/models/locomotive/editable_text_spec.rb
+++ b/spec/models/locomotive/editable_text_spec.rb
@@ -43,6 +43,10 @@ describe Locomotive::EditableText do
         @sub_page_1.editable_elements.first.content.should == 'Lorem ipsum'
       end
 
+      it 'should be from parent' do
+        @sub_page_1.editable_elements.first.from_parent.should == true
+      end
+
     end
 
     describe 'locales' do
@@ -166,6 +170,22 @@ describe Locomotive::EditableText do
         @sub_page_1_1.editable_elements.size.should == 0
       end
 
+    end
+
+    describe "element#dependents" do
+      before(:each) do
+        @sub_page_1.update_attributes raw_template: "{% extends 'parent' %}{% block main %}{% editable_text 'test', fixed: true %}Lorem ipsum{% endeditable_text %}{% editable_text 'test 2' %}This is the header{% endeditable_text %}{% endblock %}"
+      end
+
+      it "should return an empty array if there are no dependents" do
+        el = @sub_page_2.editable_elements.first
+        el.dependents.should == []
+      end
+
+      it "should return all dependent elements" do
+        @home.editable_elements.first.dependents.count.should == @home.dependents.count
+        @sub_page_1.editable_elements.where(slug: 'test').first.dependents.count.should == 1
+      end
     end
 
   end

--- a/spec/models/locomotive/page_spec.rb
+++ b/spec/models/locomotive/page_spec.rb
@@ -437,6 +437,32 @@ describe Locomotive::Page do
 
   end
 
+  describe '#dependents' do
+
+    before(:each) do
+      @site = FactoryGirl.create(:site)
+      @home = FactoryGirl.create(:page, slug: 'index', site: @site)
+      @home.update_attributes raw_template: "{% block body %}{% editable_text 'body' %}Lorem ipsum{% endeditable_text %}{% endblock %}"
+      @sub_page_1 = FactoryGirl.create(:page, slug: 'sub_page_1', parent: @home, raw_template: "{% extends 'parent' %}")
+      @sub_page_2 = FactoryGirl.create(:page, slug: 'sub_page_2', parent: @home, raw_template: "{% extends 'parent' %}")
+    end
+
+    it "should return an empty array if there are no dependent pages" do
+      @sub_page_1.dependents.should == []
+    end
+
+    it "should return all pages that dependent on it" do
+      @sub_page_1_1 = FactoryGirl.create(:page, slug: 'sub_page_1_1', parent: @sub_page_1, raw_template: "{% extends 'parent' %}")
+      @home.dependents.count.should == 3
+      @sub_page_1.dependents.count.should == 1
+    end
+
+    it "should not include a page that does not depend on it" do
+      @sub_page_2_1 = FactoryGirl.create(:page, slug: 'sub_page_2_1', parent: @sub_page_2, raw_template: "{% extends 'parent' %}")
+      @sub_page_1.dependents.count.should == 0
+    end
+  end
+
   class Foo
   end
 


### PR DESCRIPTION
When an admin updates an editable element in the template (i.e. content-three-columns template), those changes need to propagate to all editable elements that originated from this template. However, the content of dependent editable elements should not be overridden.
